### PR TITLE
Deploy using GitHub environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment:
+          - stacadmin-eoapirisk-demo
+    environment: ${{ matrix.environment }}
 
     steps:
       - name: Setup Node.js


### PR DESCRIPTION
Small change to how we're configuring deployments: Secrets are now configured in a GitHub environment so we can deploy to different instances. 
