### PR TITLE
feat: deploy GitHub Pages on releases, Cloudflare previews track branches

### DIFF
--- a/.github/workflows/deploy-gh.yml
+++ b/.github/workflows/deploy-gh.yml
@@ -2,11 +2,11 @@ name: Deploy Github Pages
 
 on:
   push:
-    branches:
-    - 'main'
+    tags:
+    - 'v*'
+  workflow_dispatch:
 
 env:
-  APP_VERSION: ${{ github.ref_name }}
   PUBLIC_URL: ${{ vars.PUBLIC_URL }}
   REACT_APP_STAC_API: ${{ vars.REACT_APP_STAC_API }}
   REACT_APP_STAC_BROWSER: ${{ vars.REACT_APP_STAC_BROWSER }}
@@ -53,6 +53,10 @@ jobs:
 
       - name: Setup SPA on Github Pages
         run: node packages/client/tasks/setup-gh-pages.mjs
+
+      - name: Set app version from release tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "APP_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
       - name: Build
         run: npm run all:build

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -60,21 +60,21 @@ Note: tags of the form `stac-manager-X.Y.Z` belong to the Helm chart, which is r
 - **Pushes to `main`** build the `:main` and `:sha-*` tags (the development tip).
 - **Release tags (`v*`)** build the `:X.Y.Z`, `:X.Y`, and `:latest` tags — so `latest` always points at the most recent release, not the latest commit.
 
-### GitHub Pages
+### GitHub Pages (releases)
 
-[`.github/workflows/deploy-gh.yml`](.github/workflows/deploy-gh.yml) builds the client on every push to `main` and deploys it to the `gh-pages` branch.
+[`.github/workflows/deploy-gh.yml`](.github/workflows/deploy-gh.yml) deploys the client to the `gh-pages` branch on every release tag (`v*`), so the GitHub Pages site always reflects the **latest release**. It can also be run manually via `workflow_dispatch`.
 
-### Cloudflare Pages
+### Cloudflare Pages (dev previews)
 
-Cloudflare Pages deployments are configured through the Cloudflare dashboard (git integration), not through a workflow in this repository. Cloudflare builds the app itself on each push: preview deployments for branches, and a production deployment for `main`.
+Cloudflare Pages deployments are configured through the Cloudflare dashboard (git integration), not through a workflow in this repository. Cloudflare builds the app itself on each push and serves **dev previews**: one per branch, with `main` acting as the development tip.
 
 ### App version stamping
 
 The version shown in the app (`process.env.APP_VERSION`) is resolved at build time, in order of precedence:
 
-1. An explicit `APP_VERSION` environment variable — set by the Docker build (branch name for branch builds, `X.Y.Z` for releases) and the GitHub Pages deploy (branch name).
-2. `CF_PAGES_BRANCH` on Cloudflare Pages preview builds (the branch name).
-3. The client `package.json` version — used by local builds and Cloudflare production builds; release-please keeps it current.
+1. An explicit `APP_VERSION` environment variable — set by the Docker build (branch name for branch builds, `X.Y.Z` for releases) and the GitHub Pages deploy (the release version).
+2. `CF_PAGES_BRANCH` on Cloudflare Pages builds (the branch name, e.g. `main` for the dev preview).
+3. The client `package.json` version — used by local builds; release-please keeps it current.
 
 Docker images built without the `APP_VERSION` build-arg retain a `%APP_VERSION%` placeholder that [`docker-entrypoint.sh`](docker-entrypoint.sh) substitutes from the container environment at startup (defaulting to `dev`).
 

--- a/packages/client/tasks/build.mjs
+++ b/packages/client/tasks/build.mjs
@@ -26,14 +26,12 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 const readPackage = () =>
   JSON.parse(fs.readFileSync(`${__dirname}/../package.json`));
 
-// Set the version in an env variable. Cloudflare Pages preview builds are
-// stamped with their branch name; production builds use the released version.
-const cfPagesBranch = process.env.CF_PAGES_BRANCH;
+// Set the version in an env variable. Cloudflare Pages dev previews are
+// stamped with their branch name; release builds receive APP_VERSION from CI.
 process.env.APP_VERSION =
   process.env.APP_VERSION ||
-  (cfPagesBranch && cfPagesBranch !== 'main'
-    ? cfPagesBranch
-    : readPackage().version);
+  process.env.CF_PAGES_BRANCH ||
+  readPackage().version;
 process.env.APP_BUILD_TIME = Date.now();
 
 // Simple task to copy the static files to the dist directory. The static


### PR DESCRIPTION
Splits the two deployment targets by role:

- **GitHub Pages = latest release.** `deploy-gh.yml` now triggers on `v*` tags (created by release-please as the DS Release Bot, so the chain works) instead of every `main` push, and stamps `APP_VERSION` with the release version (tag minus the `v`). A `workflow_dispatch` trigger is kept as a manual fallback.
- **Cloudflare Pages = dev previews.** Cloudflare builds every branch on its own; `build.mjs` now stamps all CF builds with `CF_PAGES_BRANCH` — including `main`, which previously fell back to the released package version even though it serves the dev tip.

`DEVELOPMENT.md` is updated to capture the process.

## Note for reviewers

`release-helm-chart.yml` chains off the "Deploy Github Pages" workflow (`workflow_run: completed`), because the helm repo `index.yaml` lives on the `gh-pages` branch. With this change, chart-releaser now runs after **release** deploys rather than after every `main` push — chart version bumps merged to `main` won't publish a chart release until the next app release (or a manual `workflow_dispatch` of the Pages deploy). If charts should release independently, that workflow needs its own trigger as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)