### PR TITLE
ci: enforce Conventional Commits format on PR titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    commit-message:
+      prefix: "ci"
     groups:
       minor-and-patch:
         applies-to: version-updates

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,27 @@
+# Validates that PR titles follow the Conventional Commits spec
+# (https://www.conventionalcommits.org). PRs are squash-merged, so the PR
+# title becomes the commit message on 'main' that release-please parses to
+# determine version bumps and changelog entries.
+
+name: PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate PR title against Conventional Commits
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What & why

This repo squash-merges PRs, so the **PR title becomes the commit message on `main`** — the message release-please parses to decide version bumps and changelog entries. A non-conventional title (e.g. the Dependabot `Bump …` PRs #73–#78) silently drops out of the changelog and can't trigger a release.

This PR adds a required-style check that validates PR titles against the [Conventional Commits](https://www.conventionalcommits.org) spec.

## Changes

- **`.github/workflows/pr-title.yml`** — new workflow using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) (pinned to a SHA digest, matching the repo convention from #67). Runs on `pull_request_target` `opened`/`edited`/`synchronize`/`reopened` so retitling a PR re-runs the check without a new push. The job only reads PR metadata (no checkout of PR code), so `pull_request_target` is safe here.
- **`.github/dependabot.yml`** — set `commit-message.prefix: "ci"` so Dependabot's GitHub Actions bump PRs are titled `ci: Bump …` and pass the check (and start appearing in release-please's parsed history).

Default Conventional Commit types are accepted (`feat`, `fix`, `chore`, `ci`, `docs`, `test`, `refactor`, `perf`, `build`, `style`, `revert`), which covers everything currently in `main`'s history. Breaking changes via `!` (e.g. `chore!: …`) are supported.

## Notes

- To make this blocking, add the `lint` job from the **PR Title** workflow to the branch protection / ruleset required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)