### PR TITLE
fix: redirect loop on deep links at root-domain GitHub Pages deploys

### DIFF
--- a/packages/client/tasks/setup-gh-pages.mjs
+++ b/packages/client/tasks/setup-gh-pages.mjs
@@ -33,7 +33,7 @@ async function main() {
   let segments = 0;
   if (baseUrl) {
     try {
-      segments = new URL(baseUrl).pathname.split('/').length - 1;
+      segments = new URL(baseUrl).pathname.split('/').filter(Boolean).length;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {
       // no-op


### PR DESCRIPTION
## What & why

Loading any deep link on the live Github Pages site (e.g. https://stac-manager.ds.io/collections) gets stuck in a redirect cycle, accumulating query garbage:

```
https://stac-manager.ds.io/collections/?/&/~and~/~and~/~and~/...
```

## Root cause

The site uses the [spa-github-pages](https://github.com/rafgraph/spa-github-pages) trick: `404.html` encodes the requested path into a query string and `index.html` decodes it. The encoder's `pathSegmentsToKeep` must be `0` for a site served at a domain root, but `setup-gh-pages.mjs` computed it from `PUBLIC_URL` as:

```js
segments = new URL(baseUrl).pathname.split('/').length - 1;
```

For `PUBLIC_URL=https://stac-manager.ds.io` the pathname is `'/'`, and `'/'.split('/')` is `['', '']` — so segments came out as **1**, not 0. The generated `404.html` then treated `/collections` as a repo subdirectory to preserve and redirected to `/collections/?/` — itself a 404 — and every subsequent pass through `404.html` re-encoded the query string, appending another `~and~`.

## Fix

Count only non-empty path segments:

```js
segments = new URL(baseUrl).pathname.split('/').filter(Boolean).length;
```

| PUBLIC_URL | before | after |
|---|---|---|
| `https://stac-manager.ds.io` | 1 ❌ | 0 ✅ |
| `https://stac-manager.ds.io/` | 1 ❌ | 0 ✅ |
| `https://user.github.io/repo-name` | 1 ✅ | 1 ✅ |

The decode script injected into `index.html` is unchanged — it was already correct and is verified working on the deployed site.

## Deploying the fix

The "Deploy Github Pages" workflow only runs on `v*` tags, so the live site stays broken until the next release — or run the workflow manually via `workflow_dispatch` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)