### PR TITLE
ci: merge Pages build and deploy into a single job

### DIFF
--- a/.github/workflows/deploy-gh.yml
+++ b/.github/workflows/deploy-gh.yml
@@ -19,7 +19,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
 
     steps:
@@ -38,13 +38,6 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-build-${{ hashFiles('**/package.json') }}
 
-      - name: Cache dist
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        id: cache-dist
-        with:
-          path: packages/client/dist
-          key: ${{ runner.os }}-build-${{ github.sha }}
-
       - name: Install
         run: npm install
 
@@ -60,21 +53,6 @@ jobs:
 
       - name: Build
         run: npm run all:build
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Restore dist cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        id: cache-dist
-        with:
-          path: packages/client/dist
-          key: ${{ runner.os }}-build-${{ github.sha }}
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4


### PR DESCRIPTION
## Summary

The `deploy` job restored `packages/client/dist` from `actions/cache` keyed on the commit SHA. Caches are best-effort — on eviction or a failed restore there was no `fail-on-cache-miss`, so the deploy step would publish an empty `dist` folder and (with `clean: true`) wipe the live site.

Since neither job needs environment gating or a different runner, this merges `build` and `deploy` into a single `build-and-deploy` job and removes both `Cache dist` steps. The built output now flows directly to the deploy step on the same runner, with no cross-job handoff to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)