### PR TITLE
ci: gate Helm chart release on Pages deploy success

### DIFF
--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   release:
-    if: ${{ !startsWith(github.ref, 'refs/tags/stac-manager-') }}  # prevent the helm chart releaser from running this release workflow
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}  # only release the chart when the Pages deploy succeeded
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary

The `workflow_run` trigger fires on `completed` regardless of outcome, so the chart-releaser ran even when the "Deploy Github Pages" run **failed**. This gates the job on `github.event.workflow_run.conclusion == 'success'`.

It also removes the old guard `!startsWith(github.ref, 'refs/tags/stac-manager-')`, which was dead code: in a `workflow_run` event, `github.ref` is always the repository's default branch — never a tag — so the condition was unconditionally true. The loop it guarded against can't occur anyway, since chart-releaser creates releases rather than pushing the `v*` tags that trigger the deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)