### PR TITLE
ci: use npm ci with lockfile-keyed dependency caching

### DIFF
--- a/.github/workflows/deploy-gh.yml
+++ b/.github/workflows/deploy-gh.yml
@@ -30,13 +30,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
-
-      - name: Cache node_modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        id: cache-node-modules
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-build-${{ hashFiles('**/package.json') }}
+          cache: 'npm'
 
       - name: Cache dist
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -46,7 +40,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ github.sha }}
 
       - name: Install
-        run: npm install
+        run: npm ci
 
       - name: Create .env file
         run: mv packages/client/.env.example packages/client/.env


### PR DESCRIPTION
## Summary

Two reproducibility issues in the Pages deploy workflow:

- `npm install` can resolve dependency versions that differ from `package-lock.json`, so deploys weren't guaranteed to build with the locked dependency tree. Switched to `npm ci`.
- The manual `node_modules` cache was keyed on `hashFiles('**/package.json')`, so it kept hitting even when locked versions changed, restoring a stale `node_modules`. Replaced it with `setup-node`'s built-in `cache: 'npm'`, which caches the npm download cache keyed on the lockfile — correct, and plays well with `npm ci` (which deletes `node_modules` anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)