### PR TITLE
ci: forward all REACT_APP_* repository variables to gh-pages build

### DIFF
--- a/.github/workflows/deploy-gh.yml
+++ b/.github/workflows/deploy-gh.yml
@@ -8,8 +8,6 @@ on:
 
 env:
   PUBLIC_URL: ${{ vars.PUBLIC_URL }}
-  REACT_APP_STAC_API: ${{ vars.REACT_APP_STAC_API }}
-  REACT_APP_STAC_BROWSER: ${{ vars.REACT_APP_STAC_BROWSER }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,6 +35,20 @@ jobs:
 
       - name: Create .env file
         run: mv packages/client/.env.example packages/client/.env
+
+      # Forward every repository variable prefixed with REACT_APP_ to the
+      # build environment, so new client config vars don't require workflow
+      # changes. These values end up in the public bundle; define them as
+      # variables, not secrets.
+      - name: Export REACT_APP_* vars
+        env:
+          VARS_JSON: ${{ toJSON(vars) }}
+        run: |
+          echo "$VARS_JSON" | jq -r '
+            to_entries[]
+            | select(.key | startswith("REACT_APP_"))
+            | "\(.key)<<EOF_VAR\n\(.value)\nEOF_VAR"
+          ' >> "$GITHUB_ENV"
 
       - name: Setup SPA on Github Pages
         run: node packages/client/tasks/setup-gh-pages.mjs


### PR DESCRIPTION
## What

Replaces the hardcoded `REACT_APP_STAC_API` / `REACT_APP_STAC_BROWSER` entries in the deploy-gh workflow's `env` block with a step that exports **every** repository variable prefixed with `REACT_APP_` into the build environment via `$GITHUB_ENV`.

## Why

The workflow previously only forwarded an explicit allowlist of variables, so vars like `REACT_APP_OIDC_AUTHORITY` and `REACT_APP_OIDC_CLIENT_ID` defined in the repository settings never reached the build — the deployed app silently shipped with authentication disabled. With this change, any current or future `REACT_APP_*` repository variable reaches `npm run all:build` without further workflow edits.

## Notes

- `PUBLIC_URL` stays in the top-level `env` block since it doesn't match the prefix.
- The heredoc syntax in `$GITHUB_ENV` keeps values with special characters or newlines safe.
- Only repository **variables** are forwarded, not secrets — appropriate since these values are baked into the public client bundle anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)